### PR TITLE
fix typos in KerasCV guide using RetinaNet

### DIFF
--- a/guides/keras_cv/retina_net_overview.py
+++ b/guides/keras_cv/retina_net_overview.py
@@ -42,7 +42,7 @@ resource.setrlimit(resource.RLIMIT_NOFILE, (high, high))
 ## Data loading
 
 KerasCV has a predefined specificication for bounding boxes.  To comply with this, you
-should package your bounding boxes into a dictionary matching the speciciation below:
+should package your bounding boxes into a dictionary matching the specification below:
 
 ```
 bounding_boxes = {
@@ -76,7 +76,7 @@ train_ds, ds_info = your_data_loader.load(
 Clearly yields bounding boxes in the format `xywh`.  You can read more about
 KerasCV bounding box formats [in the API docs](https://keras.io/api/keras_cv/bounding_box/formats/).
 
-Our data comesloaded into the format
+Our loaded data comes into the format
 `{"images": images, "bounding_boxes": bounding_boxes}`.  This format is supported in all
 KerasCV preprocessing components.
 
@@ -112,7 +112,7 @@ train_ds = train_ds.map(unpackage_tfds_inputs, num_parallel_calls=tf.data.AUTOTU
 eval_ds = eval_ds.map(unpackage_tfds_inputs, num_parallel_calls=tf.data.AUTOTUNE)
 
 """
-Next, lets batch our data.  In KerasCV object detection tasks it is recommended that
+Next, let's batch our data.  In KerasCV object detection tasks, it is recommended that
 users use ragged batches.  This is due to the fact that images may be of different
 sizes in PascalVOC and that there may be different numbers of bounding boxes per image.
 
@@ -255,7 +255,7 @@ Our data pipeline is now complete.  We can now move on to model creation and tra
 """
 ## Model creation
 
-We'll use the KerasCV API to construct a RetinaNet model.  In this tutorial we use
+We'll use the KerasCV API to construct a RetinaNet model. In this tutorial we use
 a pretrained ResNet50 backbone, initializing the weights to weights produced by training
 on the imagenet dataset.  In order to perform fine-tuning, we
 freeze the backbone before training.  When `include_rescaling=True` is set, inputs to
@@ -278,7 +278,7 @@ model.backbone.trainable = False
 
 """
 That is all it takes to construct a KerasCV RetinaNet.  The RetinaNet accepts tuples of
-dense image Tensors and bounding box dictionaries to `fit()` and `train_on_batch()`
+dense image Tensors and bounding box dictionaries to `fit()` and `train_on_batch()`.
 This matches what we have constructed in our input pipeline above.
 """
 


### PR DESCRIPTION
- found some misspellings and punctuation errors in KerasCV guide, so I fixed them.

Comment down below if there are any other parts to change. I will update .ipynb and .md files accordingly if all things are set!